### PR TITLE
Added a mass move note to the conversion-guide

### DIFF
--- a/docs/conversion-guide.md
+++ b/docs/conversion-guide.md
@@ -147,5 +147,16 @@ $ git add -A
 $ git commit -m 'Move file to prepare for conversion to JavaScript.'
 ```
 
-Once you've converted your file, you can run `git log --follow --
+Or if you want to move all the CoffeeScipt files within a directory and
+its subdirectory and you have access to a bash prompt:
+
+```
+$ for i in $(find . -name "*.coffee"); do git mv $i "${i%.coffee}.js" ; done
+$ git add -A
+$ git commit -m 'Moved all files to prepare for conversion to JavaScript.'
+```
+
+Once you've converted your file(s), you can run `git log --follow --
 path/to/file.js` and see the history of the `.coffee` file too.
+
+


### PR DESCRIPTION
Extended the file history section of the conversion-guide with a single-line bash command to mass move all coffee files in a directory and its sub-directories